### PR TITLE
Allow using `std::string_view` instead of `ErlNifBinary`

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Fine provides implementations for the following types:
 | `bool`                               | x       | x       |
 | `ErlNifPid`                          | x       | x       |
 | `ErlNifBinary`                       | x       | x       |
+| `std::string_view`                   | x       | x       |
 | `std::string`                        | x       | x       |
 | `fine::Atom`                         | x       | x       |
 | `std::nullopt_t`                     | x       |         |
@@ -169,9 +170,15 @@ Fine provides implementations for the following types:
 > talking about UTF-8 encoded strings or arbitrary binaries.
 >
 > However, when dealing with large binaries, it is preferable for the
-> NIF to accept `ErlNifBinary` as arguments and deal with the raw data
-> explicitly, which is zero-copy. That said, keep in mind that `ErlNifBinary`
-> is read-only and only valid during the NIF call lifetime.
+> NIF to accept `ErlNifBinary` or `std::string_view` as arguments and
+> deal with the raw data explicitly, which is zero-copy. That said,
+> keep in mind that `ErlNifBinary` and `std::string_view` are
+> read-only and only valid during the NIF call lifetime.
+>
+> Since Elixir binaries are not zero-terminated, the use of
+> `std::string` is recommended when interfacing with C APIs, although
+> this will require an additional allocation, which cannot be
+> circumvented.
 >
 > Similarly, when returning large binaries, prefer creating the term
 > with `enif_make_new_binary` and returning `fine::Term`, as shown below.

--- a/include/fine.hpp
+++ b/include/fine.hpp
@@ -5,15 +5,21 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
-#include <erl_nif.h>
 #include <map>
 #include <memory>
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <variant>
 #include <vector>
+
+#include <erl_nif.h>
+
+#if __cplusplus < 201703L
+#error "elixir-nx/fine only supports C++ 17 and later"
+#endif
 
 #if ERL_NIF_MAJOR_VERSION > 2 ||                                               \
     (ERL_NIF_MAJOR_VERSION == 2 && ERL_NIF_MINOR_VERSION >= 17)
@@ -396,11 +402,17 @@ template <> struct Decoder<ErlNifBinary> {
   }
 };
 
+template <> struct Decoder<std::string_view> {
+  static std::string_view decode(ErlNifEnv *env, const ERL_NIF_TERM &term) {
+    auto binary = fine::decode<ErlNifBinary>(env, term);
+    return std::string_view(reinterpret_cast<const char *>(binary.data),
+                            binary.size);
+  }
+};
+
 template <> struct Decoder<std::string> {
   static std::string decode(ErlNifEnv *env, const ERL_NIF_TERM &term) {
-    auto binary = fine::decode<ErlNifBinary>(env, term);
-    return std::string(
-        {reinterpret_cast<const char *>(binary.data), binary.size});
+    return std::string(fine::decode<std::string_view>(env, term));
   }
 };
 
@@ -659,8 +671,8 @@ template <> struct Encoder<ErlNifBinary> {
   }
 };
 
-template <> struct Encoder<std::string> {
-  static ERL_NIF_TERM encode(ErlNifEnv *env, const std::string &string) {
+template <> struct Encoder<std::string_view> {
+  static ERL_NIF_TERM encode(ErlNifEnv *env, const std::string_view &string) {
     ERL_NIF_TERM term;
     auto data = enif_make_new_binary(env, string.length(), &term);
     if (data == nullptr) {
@@ -668,6 +680,12 @@ template <> struct Encoder<std::string> {
     }
     memcpy(data, string.data(), string.length());
     return term;
+  }
+};
+
+template <> struct Encoder<std::string> {
+  static ERL_NIF_TERM encode(ErlNifEnv *env, const std::string &string) {
+    return fine::encode<std::string_view>(env, string);
   }
 };
 

--- a/test/c_src/finest.cpp
+++ b/test/c_src/finest.cpp
@@ -102,6 +102,11 @@ ErlNifBinary codec_binary(ErlNifEnv *, ErlNifBinary term) {
 }
 FINE_NIF(codec_binary, 0);
 
+std::string_view codec_string_view(ErlNifEnv *, std::string_view term) {
+  return term;
+}
+FINE_NIF(codec_string_view, 0);
+
 std::string codec_string(ErlNifEnv *, std::string term) { return term; }
 FINE_NIF(codec_string, 0);
 

--- a/test/lib/finest/nif.ex
+++ b/test/lib/finest/nif.ex
@@ -21,6 +21,7 @@ defmodule Finest.NIF do
   def codec_bool(_term), do: err!()
   def codec_pid(_term), do: err!()
   def codec_binary(_term), do: err!()
+  def codec_string_view(_term), do: err!()
   def codec_string(_term), do: err!()
   def codec_atom(_term), do: err!()
   def codec_nullopt(), do: err!()

--- a/test/test/finest_test.exs
+++ b/test/test/finest_test.exs
@@ -67,6 +67,16 @@ defmodule FinestTest do
       end
     end
 
+    test "string_view" do
+      assert NIF.codec_string_view("hello world") == "hello world"
+      assert NIF.codec_string_view(<<0, 1, 2>>) == <<0, 1, 2>>
+      assert NIF.codec_string_view(<<>>) == <<>>
+
+      assert_raise ArgumentError, "decode failed, expected a binary", fn ->
+        NIF.codec_string(1)
+      end
+    end
+
     test "string" do
       assert NIF.codec_string("hello world") == "hello world"
       assert NIF.codec_string(<<0, 1, 2>>) == <<0, 1, 2>>


### PR DESCRIPTION
Since `std::string_view` integrates better with the C++ ecosystem and is available in C++17, this commit ensures that it is available as an encodable and decodable type equivalent to `ErlNifBinary` while keeping `ErlNifBinary` available if needed.