### PR TITLE
Allow use when separately compiled to Fine's dependent.

### DIFF
--- a/lib/fine.ex
+++ b/lib/fine.ex
@@ -8,11 +8,9 @@ defmodule Fine do
 
   @moduledoc readme_docs
 
-  @include_dir Path.expand("include")
-
   @doc """
   Returns the directory with Fine header files.
   """
   @spec include_dir() :: String.t()
-  def include_dir(), do: @include_dir
+  def include_dir(), do: Application.app_dir(:fine, "include")
 end


### PR DESCRIPTION
Hi there!

I've recently become a user of Fine via Phoenix LiveView v1.1 → LazyHTML → Fine. I build my Elixir applications with Nix, and so have just been working out how to get the new dependency going.

The usual Nix way involves using something like [mix2nix](https://github.com/ydlr/mix2nix) — each package is built separately and reproducibly. This means Fine gets built in its own sandbox and then included in LazyHTML's build environment.

This almost works OOTB, except `@include_dir` is compiled in as a build sandbox path, which isn't available when its dependent tries to refer to its includes while building:

```
lazy_html> clang++ -shared -fPIC -fvisibility=hidden -std=c++17 -Wall -Wextra -Wno-unused-parameter -Wno-comment -I/nix/store/62pchbdm94l23xcd9c7z76pywli4v9r0-erlang-27.3.4.1/lib/erlang/erts-15.2.7/include -I/private/tmp/nix-build-fine-0.1.2.drv-0/fine-0.1.2/_build/prod/lib/fine/include -I/private/tmp/nix-build-lazy_html-0.1.3.drv-0/lazy_html-0.1.3/_build/c/third_party/lexbor/2.4.0/source -O3 -undefined dynamic_lookup -flat_namespace /private/tmp/nix-build-lazy_html-0.1.3.drv-0/lazy_html-0.1.3/c_src/lazy_html.cpp /private/tmp/nix-build-lazy_html-0.1.3.drv-0/lazy_html-0.1.3/_build/c/third_party/lexbor/2.4.0/build/liblexbor_static.a -o /private/tmp/nix-build-lazy_html-0.1.3.drv-0/lazy_html-0.1.3/_build/prod/lib/lazy_html/priv/liblazy_html.so
lazy_html> /private/tmp/nix-build-lazy_html-0.1.3.drv-0/lazy_html-0.1.3/c_src/lazy_html.cpp:3:10: fatal error: 'fine.hpp' file not found
lazy_html>     3 | #include <fine.hpp>
lazy_html>       |          ^~~~~~~~~~
lazy_html> 1 error generated.
lazy_html> make: *** [Makefile:38: /private/tmp/nix-build-lazy_html-0.1.3.drv-0/lazy_html-0.1.3/_build/prod/lib/lazy_html/priv/liblazy_html.so] Error 1
lazy_html> ** (Mix) Could not compile with "make" (exit status: 2).
```

Note the include directory:

```
-I/private/tmp/nix-build-fine-0.1.2.drv-0/fine-0.1.2/_build/prod/lib/fine/include
```

The fix is thankfully simple: use `Application.app_dir/2` to resolve Fine's installed `include` directory at runtime. The result is a build for me that looks like this:

```
lazy_html> clang++ -shared -fPIC -fvisibility=hidden -std=c++17 -Wall -Wextra -Wno-unused-parameter -Wno-comment -I/nix/store/62pchbdm94l23xcd9c7z76pywli4v9r0-erlang-27.3.4.1/lib/erlang/erts-15.2.7/include -I/private/tmp/nix-build-lazy_html-0.1.3.drv-0/lazy_html-0.1.3/_build/prod/lib/fine/include -I/private/tmp/nix-build-lazy_html-0.1.3.drv-0/lazy_html-0.1.3/_build/c/third_party/lexbor/2.4.0/source -O3 -undefined dynamic_lookup -flat_namespace /private/tmp/nix-build-lazy_html-0.1.3.drv-0/lazy_html-0.1.3/c_src/lazy_html.cpp /private/tmp/nix-build-lazy_html-0.1.3.drv-0/lazy_html-0.1.3/_build/c/third_party/lexbor/2.4.0/build/liblexbor_static.a -o /private/tmp/nix-build-lazy_html-0.1.3.drv-0/lazy_html-0.1.3/_build/prod/lib/lazy_html/priv/liblazy_html.so
```

The include directory is now:

```
-I/private/tmp/nix-build-lazy_html-0.1.3.drv-0/lazy_html-0.1.3/_build/prod/lib/fine/include
```

(Nix's BEAM/Mix compile machinery [symlinks build-time dependencies](https://github.com/NixOS/nixpkgs/blob/87cb7095bf72d5ca444e75dc7e92278e812022f8/pkgs/development/beam-modules/mix-configure-hook.sh#L13-L16) into `_build/$MIX_ENV/lib/$libraryname`.)

I haven't confirmed that this doesn't cause any unanticipated effects in other environments — only that it works for me in Nix.