### PR TITLE
Add comparison operations for fine::Term

### DIFF
--- a/c_include/fine.hpp
+++ b/c_include/fine.hpp
@@ -142,6 +142,36 @@ private:
   ERL_NIF_TERM term;
 };
 
+inline static bool operator==(const fine::Term &lhs,
+                              const fine::Term &rhs) noexcept {
+  return enif_compare(lhs, rhs) == 0;
+}
+
+inline static bool operator!=(const fine::Term &lhs,
+                              const fine::Term &rhs) noexcept {
+  return enif_compare(lhs, rhs) != 0;
+}
+
+inline static bool operator<(const fine::Term &lhs,
+                             const fine::Term &rhs) noexcept {
+  return enif_compare(lhs, rhs) < 0;
+}
+
+inline static bool operator<=(const fine::Term &lhs,
+                              const fine::Term &rhs) noexcept {
+  return enif_compare(lhs, rhs) <= 0;
+}
+
+inline static bool operator>(const fine::Term &lhs,
+                             const fine::Term &rhs) noexcept {
+  return enif_compare(lhs, rhs) > 0;
+}
+
+inline static bool operator>=(const fine::Term &lhs,
+                              const fine::Term &rhs) noexcept {
+  return enif_compare(lhs, rhs) >= 0;
+}
+
 // Represents a `:ok` tagged tuple, useful as a NIF result.
 template <typename... Args> class Ok {
 public:

--- a/test/c_src/finest.cpp
+++ b/test/c_src/finest.cpp
@@ -295,35 +295,35 @@ std::nullopt_t shared_mutex_shared_lock_test(ErlNifEnv *) {
 }
 FINE_NIF(shared_mutex_shared_lock_test, 0);
 
-bool compare_eq_test(ErlNifEnv *, fine::Term lhs, fine::Term rhs) noexcept {
+bool compare_eq(ErlNifEnv *, fine::Term lhs, fine::Term rhs) noexcept {
   return lhs == rhs;
 }
-FINE_NIF(compare_eq_test, 0);
+FINE_NIF(compare_eq, 0);
 
-bool compare_ne_test(ErlNifEnv *, fine::Term lhs, fine::Term rhs) noexcept {
+bool compare_ne(ErlNifEnv *, fine::Term lhs, fine::Term rhs) noexcept {
   return lhs != rhs;
 }
-FINE_NIF(compare_ne_test, 0);
+FINE_NIF(compare_ne, 0);
 
-bool compare_lt_test(ErlNifEnv *, fine::Term lhs, fine::Term rhs) noexcept {
+bool compare_lt(ErlNifEnv *, fine::Term lhs, fine::Term rhs) noexcept {
   return lhs < rhs;
 }
-FINE_NIF(compare_lt_test, 0);
+FINE_NIF(compare_lt, 0);
 
-bool compare_le_test(ErlNifEnv *, fine::Term lhs, fine::Term rhs) noexcept {
+bool compare_le(ErlNifEnv *, fine::Term lhs, fine::Term rhs) noexcept {
   return lhs <= rhs;
 }
-FINE_NIF(compare_le_test, 0);
+FINE_NIF(compare_le, 0);
 
-bool compare_gt_test(ErlNifEnv *, fine::Term lhs, fine::Term rhs) noexcept {
+bool compare_gt(ErlNifEnv *, fine::Term lhs, fine::Term rhs) noexcept {
   return lhs > rhs;
 }
-FINE_NIF(compare_gt_test, 0);
+FINE_NIF(compare_gt, 0);
 
-bool compare_ge_test(ErlNifEnv *, fine::Term lhs, fine::Term rhs) noexcept {
+bool compare_ge(ErlNifEnv *, fine::Term lhs, fine::Term rhs) noexcept {
   return lhs >= rhs;
 }
-FINE_NIF(compare_ge_test, 0);
+FINE_NIF(compare_ge, 0);
 } // namespace finest
 
 FINE_INIT("Elixir.Finest.NIF");

--- a/test/c_src/finest.cpp
+++ b/test/c_src/finest.cpp
@@ -295,6 +295,35 @@ std::nullopt_t shared_mutex_shared_lock_test(ErlNifEnv *) {
 }
 FINE_NIF(shared_mutex_shared_lock_test, 0);
 
+bool compare_eq_test(ErlNifEnv *, fine::Term lhs, fine::Term rhs) noexcept {
+  return lhs == rhs;
+}
+FINE_NIF(compare_eq_test, 0);
+
+bool compare_ne_test(ErlNifEnv *, fine::Term lhs, fine::Term rhs) noexcept {
+  return lhs != rhs;
+}
+FINE_NIF(compare_ne_test, 0);
+
+bool compare_lt_test(ErlNifEnv *, fine::Term lhs, fine::Term rhs) noexcept {
+  return lhs < rhs;
+}
+FINE_NIF(compare_lt_test, 0);
+
+bool compare_le_test(ErlNifEnv *, fine::Term lhs, fine::Term rhs) noexcept {
+  return lhs <= rhs;
+}
+FINE_NIF(compare_le_test, 0);
+
+bool compare_gt_test(ErlNifEnv *, fine::Term lhs, fine::Term rhs) noexcept {
+  return lhs > rhs;
+}
+FINE_NIF(compare_gt_test, 0);
+
+bool compare_ge_test(ErlNifEnv *, fine::Term lhs, fine::Term rhs) noexcept {
+  return lhs >= rhs;
+}
+FINE_NIF(compare_ge_test, 0);
 } // namespace finest
 
 FINE_INIT("Elixir.Finest.NIF");

--- a/test/lib/finest/nif.ex
+++ b/test/lib/finest/nif.ex
@@ -56,12 +56,12 @@ defmodule Finest.NIF do
   def shared_mutex_unique_lock_test(), do: err!()
   def shared_mutex_shared_lock_test(), do: err!()
 
-  def compare_eq_test(_lhs, _rhs), do: err!()
-  def compare_ne_test(_lhs, _rhs), do: err!()
-  def compare_lt_test(_lhs, _rhs), do: err!()
-  def compare_le_test(_lhs, _rhs), do: err!()
-  def compare_gt_test(_lhs, _rhs), do: err!()
-  def compare_ge_test(_lhs, _rhs), do: err!()
+  def compare_eq(_lhs, _rhs), do: err!()
+  def compare_ne(_lhs, _rhs), do: err!()
+  def compare_lt(_lhs, _rhs), do: err!()
+  def compare_le(_lhs, _rhs), do: err!()
+  def compare_gt(_lhs, _rhs), do: err!()
+  def compare_ge(_lhs, _rhs), do: err!()
 
   defp err!(), do: :erlang.nif_error(:not_loaded)
 end

--- a/test/lib/finest/nif.ex
+++ b/test/lib/finest/nif.ex
@@ -56,5 +56,12 @@ defmodule Finest.NIF do
   def shared_mutex_unique_lock_test(), do: err!()
   def shared_mutex_shared_lock_test(), do: err!()
 
+  def compare_eq_test(_lhs, _rhs), do: err!()
+  def compare_ne_test(_lhs, _rhs), do: err!()
+  def compare_lt_test(_lhs, _rhs), do: err!()
+  def compare_le_test(_lhs, _rhs), do: err!()
+  def compare_gt_test(_lhs, _rhs), do: err!()
+  def compare_ge_test(_lhs, _rhs), do: err!()
+
   defp err!(), do: :erlang.nif_error(:not_loaded)
 end

--- a/test/test/finest_test.exs
+++ b/test/test/finest_test.exs
@@ -310,39 +310,39 @@ defmodule FinestTest do
 
   describe "comparison" do
     test "equal" do
-      refute NIF.compare_eq_test(64, 42)
-      refute NIF.compare_eq_test(nil, %{})
-      assert NIF.compare_eq_test("fine", "fine")
+      refute NIF.compare_eq(64, 42)
+      refute NIF.compare_eq(nil, %{})
+      assert NIF.compare_eq("fine", "fine")
     end
 
     test "not equal" do
-      assert NIF.compare_ne_test(64, 42)
-      assert NIF.compare_ne_test(nil, %{})
-      refute NIF.compare_ne_test("fine", "fine")
+      assert NIF.compare_ne(64, 42)
+      assert NIF.compare_ne(nil, %{})
+      refute NIF.compare_ne("fine", "fine")
     end
 
     test "less than" do
-      refute NIF.compare_lt_test(64, 42)
-      assert NIF.compare_lt_test(nil, %{})
-      refute NIF.compare_lt_test("fine", "fine")
+      refute NIF.compare_lt(64, 42)
+      assert NIF.compare_lt(nil, %{})
+      refute NIF.compare_lt("fine", "fine")
     end
 
     test "less than equal" do
-      refute NIF.compare_le_test(64, 42)
-      assert NIF.compare_le_test(nil, %{})
-      assert NIF.compare_le_test("fine", "fine")
+      refute NIF.compare_le(64, 42)
+      assert NIF.compare_le(nil, %{})
+      assert NIF.compare_le("fine", "fine")
     end
 
     test "greater than" do
-      assert NIF.compare_gt_test(64, 42)
-      refute NIF.compare_gt_test(nil, %{})
-      refute NIF.compare_gt_test("fine", "fine")
+      assert NIF.compare_gt(64, 42)
+      refute NIF.compare_gt(nil, %{})
+      refute NIF.compare_gt("fine", "fine")
     end
 
     test "greater than equal" do
-      assert NIF.compare_ge_test(64, 42)
-      refute NIF.compare_ge_test(nil, %{})
-      assert NIF.compare_ge_test("fine", "fine")
+      assert NIF.compare_ge(64, 42)
+      refute NIF.compare_ge(nil, %{})
+      assert NIF.compare_ge("fine", "fine")
     end
   end
 end

--- a/test/test/finest_test.exs
+++ b/test/test/finest_test.exs
@@ -307,4 +307,42 @@ defmodule FinestTest do
       NIF.shared_mutex_shared_lock_test()
     end
   end
+
+  describe "comparison" do
+    test "equal" do
+      refute NIF.compare_eq_test(64, 42)
+      refute NIF.compare_eq_test(nil, %{})
+      assert NIF.compare_eq_test("fine", "fine")
+    end
+
+    test "not equal" do
+      assert NIF.compare_ne_test(64, 42)
+      assert NIF.compare_ne_test(nil, %{})
+      refute NIF.compare_ne_test("fine", "fine")
+    end
+
+    test "less than" do
+      refute NIF.compare_lt_test(64, 42)
+      assert NIF.compare_lt_test(nil, %{})
+      refute NIF.compare_lt_test("fine", "fine")
+    end
+
+    test "less than equal" do
+      refute NIF.compare_le_test(64, 42)
+      assert NIF.compare_le_test(nil, %{})
+      assert NIF.compare_le_test("fine", "fine")
+    end
+
+    test "greater than" do
+      assert NIF.compare_gt_test(64, 42)
+      refute NIF.compare_gt_test(nil, %{})
+      refute NIF.compare_gt_test("fine", "fine")
+    end
+
+    test "greater than equal" do
+      assert NIF.compare_ge_test(64, 42)
+      refute NIF.compare_ge_test(nil, %{})
+      assert NIF.compare_ge_test("fine", "fine")
+    end
+  end
 end


### PR DESCRIPTION
NIF terms can compare by using `enif_compare` without needing an environment parameter.  This commit simply exposes comparison by overloading operators on the `fine::Term` class.

As an aside, I also believe that strong ordering is applicable to Erlang terms, as [terms of different types have guaranteed ordering](https://www.erlang.org/doc/system/expressions.html#term-comparisons), and [NaNs are not representable in Erlang](https://www.erlang.org/doc/system/data_types.html#representation-of-floating-point-numbers).