### PR TITLE
Add hashing support compatible with std::hash

### DIFF
--- a/c_include/fine.hpp
+++ b/c_include/fine.hpp
@@ -1128,7 +1128,7 @@ template <> struct Hasher<Term> {
 };
 } // namespace __private__
 
-template <HashAlgorithm A = HashAlgorithm::INTERNAL, typename T>
+template <HashAlgorithm A = HashAlgorithm::PHASH2, typename T>
 inline static std::uint64_t hash(const T &value, std::uint64_t salt = 0) {
   return __private__::Hasher<T>::hash(A, value, salt);
 }
@@ -1199,13 +1199,13 @@ inline static std::uint64_t hash(HashAlgorithm algorithm, const T &value,
 namespace std {
 template <> struct hash<::fine::Term> {
   size_t operator()(const ::fine::Term &term) noexcept {
-    return ::fine::hash(term);
+    return ::fine::hash<::fine::HashAlgorithm::PHASH2>(term);
   }
 };
 
 template <> struct hash<::fine::Atom> {
   size_t operator()(const ::fine::Term &term) noexcept {
-    return ::fine::hash(term);
+    return ::fine::hash<::fine::HashAlgorithm::PHASH2>(term);
   }
 };
 } // namespace std

--- a/test/c_src/finest.cpp
+++ b/test/c_src/finest.cpp
@@ -1,5 +1,6 @@
 #include <cstring>
 #include <exception>
+#include <functional>
 #include <memory_resource>
 #include <optional>
 #include <stdexcept>
@@ -355,12 +356,15 @@ bool compare_ge(ErlNifEnv *, fine::Term lhs, fine::Term rhs) noexcept {
 }
 FINE_NIF(compare_ge, 0);
 
-std::uint64_t hash_test(ErlNifEnv *, fine::Term term) noexcept {
-  // Ensure the use of PHASH2. INTERNAL is not guaranteed to be stable across
-  // ERTS instances, even less so ERTS versions.
-  return fine::hash<fine::HashAlgorithm::PHASH2>(term);
+std::uint64_t term_hash_test(ErlNifEnv *, fine::Term term) noexcept {
+  return std::invoke(std::hash<fine::Term>{}, term);
 }
-FINE_NIF(hash_test, 0);
+FINE_NIF(term_hash_test, 0);
+
+std::uint64_t atom_hash_test(ErlNifEnv *, fine::Atom atom) noexcept {
+  return std::invoke(std::hash<fine::Atom>{}, atom);
+}
+FINE_NIF(atom_hash_test, 0);
 
 } // namespace finest
 

--- a/test/c_src/finest.cpp
+++ b/test/c_src/finest.cpp
@@ -356,15 +356,15 @@ bool compare_ge(ErlNifEnv *, fine::Term lhs, fine::Term rhs) noexcept {
 }
 FINE_NIF(compare_ge, 0);
 
-std::uint64_t term_hash_test(ErlNifEnv *, fine::Term term) noexcept {
+std::uint64_t hash_term(ErlNifEnv *, fine::Term term) noexcept {
   return std::invoke(std::hash<fine::Term>{}, term);
 }
-FINE_NIF(term_hash_test, 0);
+FINE_NIF(hash_term, 0);
 
-std::uint64_t atom_hash_test(ErlNifEnv *, fine::Atom atom) noexcept {
+std::uint64_t hash_atom(ErlNifEnv *, fine::Atom atom) noexcept {
   return std::invoke(std::hash<fine::Atom>{}, atom);
 }
-FINE_NIF(atom_hash_test, 0);
+FINE_NIF(hash_atom, 0);
 
 } // namespace finest
 

--- a/test/c_src/finest.cpp
+++ b/test/c_src/finest.cpp
@@ -354,6 +354,14 @@ bool compare_ge(ErlNifEnv *, fine::Term lhs, fine::Term rhs) noexcept {
   return lhs >= rhs;
 }
 FINE_NIF(compare_ge, 0);
+
+std::uint64_t hash_test(ErlNifEnv *, fine::Term term) noexcept {
+  // Ensure the use of PHASH2. INTERNAL is not guaranteed to be stable across
+  // ERTS instances, even less so ERTS versions.
+  return fine::hash<fine::HashAlgorithm::PHASH2>(term);
+}
+FINE_NIF(hash_test, 0);
+
 } // namespace finest
 
 FINE_INIT("Elixir.Finest.NIF");

--- a/test/lib/finest/nif.ex
+++ b/test/lib/finest/nif.ex
@@ -66,7 +66,8 @@ defmodule Finest.NIF do
   def compare_gt(_lhs, _rhs), do: err!()
   def compare_ge(_lhs, _rhs), do: err!()
 
-  def hash_test(_term), do: err!()
+  def term_hash_test(_term), do: err!()
+  def atom_hash_test(_term), do: err!()
 
   defp err!(), do: :erlang.nif_error(:not_loaded)
 end

--- a/test/lib/finest/nif.ex
+++ b/test/lib/finest/nif.ex
@@ -66,5 +66,7 @@ defmodule Finest.NIF do
   def compare_gt(_lhs, _rhs), do: err!()
   def compare_ge(_lhs, _rhs), do: err!()
 
+  def hash_test(_term), do: err!()
+
   defp err!(), do: :erlang.nif_error(:not_loaded)
 end

--- a/test/lib/finest/nif.ex
+++ b/test/lib/finest/nif.ex
@@ -66,8 +66,8 @@ defmodule Finest.NIF do
   def compare_gt(_lhs, _rhs), do: err!()
   def compare_ge(_lhs, _rhs), do: err!()
 
-  def term_hash_test(_term), do: err!()
-  def atom_hash_test(_term), do: err!()
+  def hash_term(_term), do: err!()
+  def hash_atom(_term), do: err!()
 
   defp err!(), do: :erlang.nif_error(:not_loaded)
 end

--- a/test/test/finest_test.exs
+++ b/test/test/finest_test.exs
@@ -353,9 +353,15 @@ defmodule FinestTest do
   end
 
   describe "hash" do
-    test "phash2" do
-      for elem <- [42, "fine", ["it", %{"should" => {"just", "work"}}]] do
-        assert NIF.hash_test(elem) == :erlang.phash2(elem)
+    test "term" do
+      for value <- [42, "fine", ["it", %{"should" => {"just", "work"}}], :atom] do
+        assert NIF.term_hash_test(value) == NIF.term_hash_test(value)
+      end
+    end
+
+    test "atom" do
+      for value <- [:ok, :error, :"with spaces", Enum, nil, true, false] do
+        assert NIF.atom_hash_test(value) == NIF.atom_hash_test(value)
       end
     end
   end

--- a/test/test/finest_test.exs
+++ b/test/test/finest_test.exs
@@ -355,13 +355,13 @@ defmodule FinestTest do
   describe "hash" do
     test "term" do
       for value <- [42, "fine", ["it", %{"should" => {"just", "work"}}], :atom] do
-        assert NIF.term_hash_test(value) == NIF.term_hash_test(value)
+        assert NIF.hash_term(value) == NIF.hash_term(value)
       end
     end
 
     test "atom" do
       for value <- [:ok, :error, :"with spaces", Enum, nil, true, false] do
-        assert NIF.atom_hash_test(value) == NIF.atom_hash_test(value)
+        assert NIF.hash_atom(value) == NIF.hash_atom(value)
       end
     end
   end

--- a/test/test/finest_test.exs
+++ b/test/test/finest_test.exs
@@ -351,4 +351,12 @@ defmodule FinestTest do
       assert NIF.compare_ge("fine", "fine")
     end
   end
+
+  describe "hash" do
+    test "phash2" do
+      for elem <- [42, "fine", ["it", %{"should" => {"just", "work"}}]] do
+        assert NIF.hash_test(elem) == :erlang.phash2(elem)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This will allow `fine::Atom`s and `fine::Term`s to be used as `std::map`, and `std::unordered_map` keys if merged with #10.