### PR TITLE
Add fine::Result type

### DIFF
--- a/test/c_src/finest.cpp
+++ b/test/c_src/finest.cpp
@@ -171,6 +171,30 @@ fine::Ok<int64_t> codec_ok_int64(ErlNifEnv *, int64_t term) {
 }
 FINE_NIF(codec_ok_int64, 0);
 
+fine::Result<int64_t, std::string>
+codec_result_int64_string_ok_explicit(ErlNifEnv *, int64_t term) {
+  return fine::Ok<int64_t>{term};
+}
+FINE_NIF(codec_result_int64_string_ok_explicit, 0);
+
+fine::Result<int64_t, std::string>
+codec_result_int64_string_error_explicit(ErlNifEnv *, std::string term) {
+  return fine::Error<std::string>{term};
+}
+FINE_NIF(codec_result_int64_string_error_explicit, 0);
+
+fine::Result<int64_t, std::string>
+codec_result_int64_string_ok_implicit(ErlNifEnv *, int64_t term) {
+  return static_cast<int32_t>(term);
+}
+FINE_NIF(codec_result_int64_string_ok_implicit, 0);
+
+fine::Result<int64_t, std::string>
+codec_result_int64_string_error_conversion(ErlNifEnv *) {
+  return fine::Error{"constant string"};
+}
+FINE_NIF(codec_result_int64_string_error_conversion, 0);
+
 fine::Error<> codec_error_empty(ErlNifEnv *) { return fine::Error(); }
 FINE_NIF(codec_error_empty, 0);
 

--- a/test/lib/finest/nif.ex
+++ b/test/lib/finest/nif.ex
@@ -37,6 +37,10 @@ defmodule Finest.NIF do
   def codec_ok_int64(_term), do: err!()
   def codec_error_empty(), do: err!()
   def codec_error_string(_term), do: err!()
+  def codec_result_int64_string_ok_explicit(_term), do: err!()
+  def codec_result_int64_string_error_explicit(_term), do: err!()
+  def codec_result_int64_string_ok_implicit(_term), do: err!()
+  def codec_result_int64_string_error_conversion(), do: err!()
 
   def resource_create(_pid), do: err!()
   def resource_get(_resource), do: err!()

--- a/test/test/finest_test.exs
+++ b/test/test/finest_test.exs
@@ -217,6 +217,16 @@ defmodule FinestTest do
       assert NIF.codec_error_empty() == :error
       assert NIF.codec_error_string("this is the reason") == {:error, "this is the reason"}
     end
+
+    test "ok result" do
+      assert NIF.codec_result_int64_string_ok_explicit(42) == {:ok, 42}
+      assert NIF.codec_result_int64_string_ok_implicit(201_703) == {:ok, 201_703}
+    end
+
+    test "error result" do
+      assert NIF.codec_result_int64_string_error_explicit("some error") == {:error, "some error"}
+      assert NIF.codec_result_int64_string_error_conversion() == {:error, "constant string"}
+    end
   end
 
   describe "resource" do


### PR DESCRIPTION
Built on top of `fine::Ok<Args...>` and `fine::Error<Args...>`, `fine::Result<T, E>` offers more user-friendly ergonomics to handling result types from NIF functions by allowing implicit conversion of success and error types when possible.

While similar in behaviour to `std::expected<T, E>`, the goal of `fine::Result<T, E>` is not to replace it.  `fine::Result<T, E>`, by design, only supports construction and assignment to prevent peeking into its state.