### PR TITLE
Add condition variable wrapper

### DIFF
--- a/c_include/fine/sync.hpp
+++ b/c_include/fine/sync.hpp
@@ -258,6 +258,9 @@ public:
   // This function is thread-safe.
   void notify_one() noexcept { enif_cond_signal(m_handle.get()); }
 
+  // Prefer the use of `wait(std::unique_lock<Mutex>&, Predicate)` over this
+  // function.
+  //
   // Waits on a condition variable. The calling thread is blocked until another
   // thread wakes it by signaling or broadcasting on the condition variable.
   // Before the calling thread is blocked, it unlocks the mutex passed as
@@ -272,9 +275,6 @@ public:
   // occurred, and if not call `wait` again.
   //
   // This function is thread-safe.
-  [[deprecated(
-      "usage of `void fine::ConditionVariable::wait(std::unique_lock<Mutex> "
-      "&, Predicate)` is preferred")]]
   void wait(std::unique_lock<Mutex> &lock) noexcept {
     enif_cond_wait(m_handle.get(), *lock.mutex());
   }

--- a/test/c_src/finest.cpp
+++ b/test/c_src/finest.cpp
@@ -425,7 +425,6 @@ FINE_NIF(shared_mutex_shared_lock_test, 0);
 
 class ResetEvent {
 public:
-public:
   explicit ResetEvent(const bool signaled = false) noexcept
       : m_signaled{signaled} {}
 

--- a/test/lib/finest/nif.ex
+++ b/test/lib/finest/nif.ex
@@ -70,6 +70,8 @@ defmodule Finest.NIF do
   def shared_mutex_unique_lock_test(), do: err!()
   def shared_mutex_shared_lock_test(), do: err!()
 
+  def condition_variable_test(), do: err!()
+
   def compare_eq(_lhs, _rhs), do: err!()
   def compare_ne(_lhs, _rhs), do: err!()
   def compare_lt(_lhs, _rhs), do: err!()

--- a/test/test/finest_test.exs
+++ b/test/test/finest_test.exs
@@ -451,6 +451,12 @@ defmodule FinestTest do
     end
   end
 
+  describe "condition_variable" do
+    test "condition_variable" do
+      NIF.condition_variable_test()
+    end
+  end
+
   describe "comparison" do
     test "equal" do
       refute NIF.compare_eq(64, 42)


### PR DESCRIPTION
In line with `fine::Mutex` and `fine::SharedMutex`, this commit adds a wrapper, `fine::ConditionVariable` for `ErlNifCond` with an API similar if not identifical to `std::condition_variable`.