### PR TITLE
Update versions on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
           - { name: "macOS", id: "macos-14" }
         pair:
           - { elixir: "1.15.8", otp: "25.3" }
-          - { elixir: "1.18.2", otp: "27.2" }
           - { elixir: "1.19.5", otp: "28.4" }
     env:
       MIX_ENV: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
       MIX_ENV: test
     name: Lint
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "27.2"
-          elixir-version: "1.18.2"
+          otp-version: "28"
+          elixir-version: "1.19"
       - run: mix deps.get --check-locked
       - run: mix deps.compile
       - run: mix format --check-formatted
@@ -35,11 +35,12 @@ jobs:
         pair:
           - { elixir: "1.15.8", otp: "25.3" }
           - { elixir: "1.18.2", otp: "27.2" }
+          - { elixir: "1.19.5", otp: "28.4" }
     env:
       MIX_ENV: test
     name: Test (${{ matrix.os.name }}, ${{ matrix.pair.elixir }}, ${{ matrix.pair.otp }})
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ matrix.pair.otp }}


### PR DESCRIPTION
List of changes:
- bump actions/checkout from v4 to v6
- bump lint Elixir/OTP from 1.18/27 to 1.19/28
- add Elixir 1.19/OTP 28 to test matrix